### PR TITLE
Revert failed updates

### DIFF
--- a/ghostfolio/CHANGELOG.md
+++ b/ghostfolio/CHANGELOG.md
@@ -1,37 +1,25 @@
 ## Ghostfolio Release Notes
 
-### [`v2.90.0`](https://togithub.com/ghostfolio/ghostfolio/blob/HEAD/CHANGELOG.md#2900---2024-06-22)
+### [`v2.89.0`](https://togithub.com/ghostfolio/ghostfolio/blob/HEAD/CHANGELOG.md#2890---2024-06-14)
 
-[Compare Source](https://togithub.com/ghostfolio/ghostfolio/compare/2.89.0...2.90.0)
+[Compare Source](https://togithub.com/ghostfolio/ghostfolio/compare/2.88.0...2.89.0)
 
 ##### Added
 
--   Added a dialog for the benchmarks in the markets overview
--   Extended the asset profile details dialog of the admin control for currencies
--   Extended the content of the *Self-Hosting* section by the mobile app question on the Frequently Asked Questions (FAQ) page
+-   Extended the historical market data table with currencies preset by date and activities count in the admin control panel
 
 ##### Changed
 
--   Moved the indicator for active filters from experimental to general availability
--   Improved the error handling in the biometric authentication registration
+-   Improved the date validation in the create, import and update activities endpoints
 -   Improved the language localization for German (`de`)
--   Set up SSL for local development
--   Upgraded the *Stripe* dependencies
--   Upgraded `marked` from version `9.1.6` to `13.0.0`
--   Upgraded `ngx-device-detector` from version `5.0.1` to `8.0.0`
--   Upgraded `ngx-markdown` from version `17.1.1` to `18.0.0`
--   Upgraded `zone.js` from version `0.14.5` to `0.14.7`
 
----
-
-## Add-on Release Notes
-
-
+---\n\n## Add-on Release Notes\n\n
 
 
 ## What's Changed
-* Interpret newlines when generating release notes by @lildude in https://github.com/lildude/ha-addon-ghostfolio/pull/51
-* Update Ghostfolio to v2.90.0 by @renovate in https://github.com/lildude/ha-addon-ghostfolio/pull/53
+* Make it clearer which are the addon release notes by @lildude in https://github.com/lildude/ha-addon-ghostfolio/pull/48
+* Update actions/checkout action to v4.1.7 by @renovate in https://github.com/lildude/ha-addon-ghostfolio/pull/49
+* Update Ghostfolio to v2.89.0 by @renovate in https://github.com/lildude/ha-addon-ghostfolio/pull/50
 
 
-**Full Changelog**: https://github.com/lildude/ha-addon-ghostfolio/compare/v1.15.0...v1.16.0
+**Full Changelog**: https://github.com/lildude/ha-addon-ghostfolio/compare/v1.14.0...v1.15.0

--- a/ghostfolio/CHANGELOG.md
+++ b/ghostfolio/CHANGELOG.md
@@ -32,7 +32,6 @@
 ## What's Changed
 * Interpret newlines when generating release notes by @lildude in https://github.com/lildude/ha-addon-ghostfolio/pull/51
 * Update Ghostfolio to v2.90.0 by @renovate in https://github.com/lildude/ha-addon-ghostfolio/pull/53
-* Update softprops/action-gh-release action to v2.0.6 by @renovate in https://github.com/lildude/ha-addon-ghostfolio/pull/52
 
 
-**Full Changelog**: https://github.com/lildude/ha-addon-ghostfolio/compare/v1.15.0...v1.16.0
+**Full Changelog**: https://github.com/lildude/ha-addon-ghostfolio/compare/v1.15.0...v1.17.0

--- a/ghostfolio/CHANGELOG.md
+++ b/ghostfolio/CHANGELOG.md
@@ -34,4 +34,4 @@
 * Update Ghostfolio to v2.90.0 by @renovate in https://github.com/lildude/ha-addon-ghostfolio/pull/53
 
 
-**Full Changelog**: https://github.com/lildude/ha-addon-ghostfolio/compare/v1.15.0...v1.17.0
+**Full Changelog**: https://github.com/lildude/ha-addon-ghostfolio/compare/v1.15.0...v1.16.0

--- a/ghostfolio/config.json
+++ b/ghostfolio/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Ghostfolio",
-  "version": "1.16.0",
+  "version": "1.15.0",
   "slug": "ghostfolio",
   "description": "Privacy-first, open source dashboard for your personal finances.",
   "url": "https://github.com/lildude/ha-addon-ghostfolio",

--- a/ghostfolio/config.json
+++ b/ghostfolio/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Ghostfolio",
-  "version": "1.16.0",
+  "version": "1.17.0",
   "slug": "ghostfolio",
   "description": "Privacy-first, open source dashboard for your personal finances.",
   "url": "https://github.com/lildude/ha-addon-ghostfolio",

--- a/ghostfolio/config.json
+++ b/ghostfolio/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Ghostfolio",
-  "version": "1.17.0",
+  "version": "1.16.0",
   "slug": "ghostfolio",
   "description": "Privacy-first, open source dashboard for your personal finances.",
   "url": "https://github.com/lildude/ha-addon-ghostfolio",


### PR DESCRIPTION
The releaser action of the ghostfolio-addon is suddenly having problems so the images aren't being built. Reverting these updates as they're not accurate.